### PR TITLE
fix(core): fix nickname error, close #7

### DIFF
--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -67,15 +67,11 @@ const cheatSheet = (session: Dialogue.Session, config: Dialogue.Config) => {
 　$$：一个普通的 $ 字符
 　$0：收到的原文本
 　$n：分条发送
-　$a：@说话人`,470);
-if (session.app.config.nickname != null) {
-  output.add(`　$m：@${session.app.config.nickname[0]}`, 460);
-} else {
-  output.add(`　$m：@${session.bot.username}`, 460);
-}
-  output.add(`　$s：说话人的名字
+　$a：@说话人
+　$m：@${session.app.config.nickname?.[0] ?? session.bot.username}
+　$s：说话人的名字
 　\$()：指令插值
-　\${}：表达式插值`, 0);
+　\${}：表达式插值`, 0)
   session.app.emit('dialogue/usage', output, session)
   return output.toString()
 }

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -67,11 +67,15 @@ const cheatSheet = (session: Dialogue.Session, config: Dialogue.Config) => {
 　$$：一个普通的 $ 字符
 　$0：收到的原文本
 　$n：分条发送
-　$a：@说话人
-　$m：@${session.app.config.nickname[0]}
-　$s：说话人的名字
+　$a：@说话人`,470);
+if (session.app.config.nickname != null) {
+  output.add(`　$m：@${session.app.config.nickname[0]}`, 460);
+} else {
+  output.add(`　$m：@${session.bot.username}`, 460);
+}
+  output.add(`　$s：说话人的名字
 　\$()：指令插值
-　\${}：表达式插值`, 0)
+　\${}：表达式插值`, 0);
   session.app.emit('dialogue/usage', output, session)
   return output.toString()
 }


### PR DESCRIPTION
当bot的nickname未设置时后台报错
2023-03-17 00:04:15 [W] command help teach
TypeError: Cannot read properties of undefined (reading '0')
at cheatSheet (/koishi/node_modules/koishi-plugin-dialogue/lib/index.js:354:32)
at _Command._usage (/koishi/node_modules/koishi-plugin-dialogue/lib/index.js:418:173)
at showHelp (/koishi/node_modules/@koishijs/plugin-help/lib/index.js:265:85)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async Array.<anonymous> (/koishi/node_modules/@koishijs/core/lib/index.cjs:1648:14)
at async _Command.execute (/koishi/node_modules/@koishijs/core/lib/index.cjs:1663:22)
at async /koishi/node_modules/@koishijs/core/lib/index.cjs:2221:22
at async Session2.withScope (/koishi/node_modules/@koishijs/core/lib/index.cjs:2104:14)
at async Lifecycle.serial (/koishi/node_modules/cordis/lib/index.cjs:107:22)
at async _Command.execute (/koishi/node_modules/@koishijs/core/lib/index.cjs:1640:22)
此处增加了一层判断，当nickname未设置时默认使用bot的qq昵称